### PR TITLE
Organize the build file using task groups

### DIFF
--- a/buildfile.m
+++ b/buildfile.m
@@ -1,4 +1,5 @@
 function plan = buildfile
+
 % Create a plan from the task functions
 plan = buildplan(localfunctions);
 
@@ -19,12 +20,12 @@ end
 plan("build:mex").Description = "Build MEX functions";
 plan("build").Description = "Build the toolbox";
 
-% Define the "check" task
+% Define the "check" task as a sub task of validate
 sourceFolder = files(plan, "toolbox");
 plan("validate:check") = matlab.buildtool.tasks.CodeIssuesTask(sourceFolder,...
     IncludeSubfolders = true);
 
-% Define the "test" task
+% Define the "test" task as a sub task of validate 
 testsFolder = files(plan, "tests");
 plan("validate:test") = matlab.buildtool.tasks.TestTask(testsFolder,...
     IncludeSubfolders = true, OutputDetail = "terse");
@@ -32,12 +33,15 @@ plan("validate:test") = matlab.buildtool.tasks.TestTask(testsFolder,...
 
 plan("validate").Description = "Validate the toolbox";
 
-% Make the "test" task the default task in the plan
+% Make "build" task group the default task
 plan.DefaultTasks = "build";
 
-% Make the "release" task dependent on the "check" and "test" tasks
-plan("package").Dependencies = ["build" "validate"];
-plan("package").Outputs = "release\Arithmetic_Toolbox.mltbx";
+% Make the "validate" task dependent on "build" task group
+plan("validate").Dependencies = "build";
+
+% Make the "package" task dependent on "validate" task group
+plan("package").Dependencies = "validate";
+plan("package").Outputs = fullfile("release","Arithmetic_Toolbox.mltbx");
 end
 
 function packageTask(~)

--- a/buildfile.m
+++ b/buildfile.m
@@ -12,31 +12,38 @@ mexOutputFolder = fullfile("toolbox","derived");
 foldersToMex = plan.files(fullfile("cpp", "*Mex")).select(@isfolder);
 for folder = foldersToMex.paths
     [~, folderName] = fileparts(folder);
-    plan("mex:"+folderName) = matlab.buildtool.tasks.MexTask(fullfile(folder, "**/*.cpp"), ...
+    plan("build:mex:"+folderName) = matlab.buildtool.tasks.MexTask(fullfile(folder, "**/*.cpp"), ...
         mexOutputFolder, ...
         Filename=folderName);
 end
-plan("mex").Description = "Build MEX functions";
+plan("build:mex").Description = "Build MEX functions";
+plan("build").Description = "Build the toolbox";
 
 % Define the "check" task
 sourceFolder = files(plan, "toolbox");
-plan("check") = matlab.buildtool.tasks.CodeIssuesTask(sourceFolder,...
+plan("validate:check") = matlab.buildtool.tasks.CodeIssuesTask(sourceFolder,...
     IncludeSubfolders = true);
 
 % Define the "test" task
 testsFolder = files(plan, "tests");
-plan("test") = matlab.buildtool.tasks.TestTask(testsFolder,...
+plan("validate:test") = matlab.buildtool.tasks.TestTask(testsFolder,...
     IncludeSubfolders = true, OutputDetail = "terse");
 
+
+plan("validate:dependency") = matlab.buildtool.Task();
+plan("validate:dependency").Actions = @dependencyAnalysis;
+
+plan("validate").Description = "Validate the toolbox";
+
 % Make the "test" task the default task in the plan
-plan.DefaultTasks = ["mex" "test"];
+plan.DefaultTasks = "build";
 
 % Make the "release" task dependent on the "check" and "test" tasks
-plan("release").Dependencies = ["mex" "check" "test"];
-plan("release").Outputs = "release\Arithmetic_Toolbox.mltbx";
+plan("package").Dependencies = ["build" "validate"];
+plan("package").Outputs = "release\Arithmetic_Toolbox.mltbx";
 end
 
-function releaseTask(~)
+function packageTask(~)
 % Create an MLTBX package
 releaseFolderName = "release";
 if isMATLABReleaseOlderThan("R2025a")

--- a/buildfile.m
+++ b/buildfile.m
@@ -30,9 +30,6 @@ plan("validate:test") = matlab.buildtool.tasks.TestTask(testsFolder,...
     IncludeSubfolders = true, OutputDetail = "terse");
 
 
-plan("validate:dependency") = matlab.buildtool.Task();
-plan("validate:dependency").Actions = @dependencyAnalysis;
-
 plan("validate").Description = "Validate the toolbox";
 
 % Make the "test" task the default task in the plan


### PR DESCRIPTION
This PR proposes the following changes to `buildfile.m`
- Introduced new task groups for build and validate. These task groups now have subtasks
- Renamed releaseTask to  packageTask

Aligning the `buildfile.m` with our current thinking.